### PR TITLE
refator: Correct text of Login button

### DIFF
--- a/Android/app/src/main/res/layout/activity_login.xml
+++ b/Android/app/src/main/res/layout/activity_login.xml
@@ -229,7 +229,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1.0"
                     android:gravity="start"
-                    android:text="@string/login"
+                    android:text="@string/text_login"
                     android:visibility="gone"
                     android:textAlignment="center"
                     android:textColor="#ffffff" />

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="phone_number">Phone Number</string>
     <string name="email_id">Email id</string>
     <string name="password">Password</string>
-    <string name="login"><u>Already a member? Login</u></string>
+    <string name="login">Login</string>
     <string name="signup">Signup</string>
     <string name="name">Name</string>
     <string name="toast_invalid_username_or_password">Invalid username or password</string>
@@ -136,6 +136,7 @@
     <string name="text_shopping">Shopping</string>
     <string name="text_restaurants">Restaurants</string>
     <string name="text_city_trends">City Trends</string>
+    <string name="text_login"><u>Already a member? Login</u></string>
     <string name="text_signup_or"><u>Not registered yet? Create new account</u></string>
     <string name="text_cart">Car</string>
     <string name="text_train">Train</string>


### PR DESCRIPTION
In continuation of #115.

Fixed the text of the Login button from `Already a member? Login` to `Login`. @Swati4star I think we both overlooked it. Anyways, its fixed now.