### PR TITLE
Weather icon not loading for haze condition #362

### DIFF
--- a/Android/app/src/main/assets/icons.json
+++ b/Android/app/src/main/assets/icons.json
@@ -206,7 +206,7 @@
 
   "721": {
     "label": "haze",
-    "icon": "day_haze"
+    "icon": "haze"
   },
 
   "731": {


### PR DESCRIPTION
Fixes #362.
![screenshot_20180729-143016](https://user-images.githubusercontent.com/26850482/43364901-551a2ea8-9341-11e8-8eaf-289184fa080b.png)
