### PR TITLE
Fixed issue #473 of showing empty state in restaurants activity

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/RestaurantsActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/RestaurantsActivity.java
@@ -217,6 +217,12 @@ public class RestaurantsActivity extends AppCompatActivity implements Restaurant
                 final String res = Objects.requireNonNull(response.body()).string();
 
                 mHandler.post(() -> {
+
+                    if (res.equals("\"Not Found\"") || res.contains("Not Found")) {
+                        notFoundError();
+                        return;
+                    }
+
                     try {
                         JSONArray array = new JSONArray(res);
                         Log.v(TAG, "Response = " + res );
@@ -249,6 +255,15 @@ public class RestaurantsActivity extends AppCompatActivity implements Restaurant
 
             }
         });
+    }
+
+    /**
+     * Plays the Not Found animation in the view
+     */
+    private void notFoundError() {
+        animationView.setAnimation(R.raw.empty_list);
+        animationView.playAnimation();
+        animationView.setOnClickListener(v -> getRestaurantItems());
     }
 
     /**


### PR DESCRIPTION
## Description

This pull request adds the code for showing empty state in ```RestaurantsActivity``` when it gets a response of ```Not Found``` from the API endpoint.

Fixes #473 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
