### PR TITLE
Upgrade to sdk 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
 # Support library
     - extra-android-support
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: android
 jdk: oraclejdk8
 android:
   components:
-    - tools
     - platform-tools
     - tools
     - build-tools-28.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 jdk: oraclejdk8
 android:
   components:
+    - tools
     - platform-tools
     - tools
     - build-tools-28.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ android:
   licenses:
     - '.+'
 
+before_install:
+    - yes | sdkmanager "platforms;android-28"
+
 before_script:
     - cd Android
     - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-28.0.3
+    - build-tools-28.0.2
     - android-28
 # Support library
     - extra-android-support
@@ -14,9 +14,6 @@ android:
     - extra-google-m2repository
   licenses:
     - '.+'
-
-before_install:
-    - yes | sdkmanager "platforms;android-28"
 
 before_script:
     - cd Android

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -4,12 +4,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
     defaultConfig {
         applicationId "io.github.project_travel_mate"
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 17
         versionName "3.9.2"
     }

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.4.0'
 
     // Lottie : animations
-    implementation 'com.airbnb.android:lottie:2.5.5'
+    implementation 'com.airbnb.android:lottie:2.7.0'
 
     // To show what's new in the application
     implementation 'io.github.tonnyl:whatsnew:0.1.1'

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 


### PR DESCRIPTION
## Description

I upgrade the project to SDK 28 and removed the `buildToolsVersion` field, because is not needed from android gradle plugin 3.0.0 and up, see [here](https://developer.android.com/studio/releases/build-tools):

> If you're using Android plugin for Gradle 3.0.0 or higher, your project automatically uses a default version of the build tools that the plugin specifies

After upgrade I tested and it crash because of lottie lib:
```
ava.lang.IllegalArgumentException: Invalid Layer Save Flag - only ALL_SAVE_FLAGS is allowed
at android.graphics.Canvas.checkValidSaveFlags(Canvas.java:378)
at android.graphics.Canvas.saveLayer(Canvas.java:455)
at com.airbnb.lottie.model.layer.BaseLayer.draw(BaseLayer.java:224)
at com.airbnb.lottie.model.layer.CompositionLayer.drawLayer(CompositionLayer.java:100)
at com.airbnb.lottie.model.layer.BaseLayer.draw(BaseLayer.java:190)
at com.airbnb.lottie.LottieDrawable.draw(LottieDrawable.java:312)
at android.widget.ImageView.onDraw(ImageView.java:1360)
at android.view.View.draw(View.java:20205)
at android.view.View.updateDisplayListIfDirty(View.java:19080)
at android.view.View.draw(View.java:19933)
at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
at android.view.View.draw(View.java:20208)
at android.view.View.updateDisplayListIfDirty(View.java:19080)
at android.view.View.draw(View.java:19933)
at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
at android.view.View.updateDisplayListIfDirty(View.java:19071)
at android.view.View.draw(View.java:19933)
at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
at android.view.View.updateDisplayListIfDirty(View.java:19071)
at android.view.View.draw(View.java:19933)
at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
at android.view.View.draw(View.java:20208)
at com.android.internal.policy.DecorView.draw(DecorView.java:780)
at android.view.View.updateDisplayListIfDirty(View.java:19080)
at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:685)
at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:691)
at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:799)
at android.view.ViewRootImpl.draw(ViewRootImpl.java:3263)
at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3079)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2459)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1447)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7130)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:935)
at android.view.Choreographer.doCallbacks(Choreographer.java:747)
at android.view.Choreographer.doFrame(Choreographer.java:682)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:921)
at android.os.Handler.handleCallback(Handler.java:873)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:193)
at android.app.ActivityThread.main(ActivityThread.java:6642)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

The fix was to upgrade the lottie version to `2.7.0`, take into account that `2.8.0` is the last one, but requires support for `androidx`.

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
