### PR TITLE
Fix duplicate trips getting added on refreshing

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/mytrips/MyTripsFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/mytrips/MyTripsFragment.java
@@ -82,7 +82,7 @@ public class MyTripsFragment extends Fragment implements SwipeRefreshLayout.OnRe
         swipeRefreshLayout.setOnRefreshListener(this);
         mRecyclerView.setHasFixedSize(true);
         mRecyclerView.setLayoutManager(getLayoutManager());
-        mMyTripsAdapter = new TripsListAdapter(mActivity.getApplicationContext(), mTripList);
+        mMyTripsAdapter = new TripsListAdapter(mTripList);
         mMyTripsAdapter.setOnItemClickListener((position, v) -> {
             Intent intent = MyTripInfoActivity.getStartIntent(mActivity.getApplicationContext(),
                     mTripList.get(position));
@@ -121,9 +121,10 @@ public class MyTripsFragment extends Fragment implements SwipeRefreshLayout.OnRe
             }
 
             @Override
-            public void onResponse(Call call, final Response response) throws IOException {
+            public void onResponse(Call call, final Response response) {
 
                 mHandler.post(() -> {
+                    swipeRefreshLayout.setRefreshing(false);
                     if (response.isSuccessful() && response.body() != null) {
                         JSONArray arr;
                         try {
@@ -145,8 +146,8 @@ public class MyTripsFragment extends Fragment implements SwipeRefreshLayout.OnRe
                                 String image = arr.getJSONObject(i).getJSONObject("city").getString("image");
                                 mTripList.add(new Trip(id, name, image, start, end, tname));
                                 animationView.setVisibility(View.GONE);
-                                mMyTripsAdapter.notifyItemInserted(arr.length() - i - 1);
                             }
+                            mMyTripsAdapter.notifyItemRangeInserted(0, arr.length());
 
                         } catch (JSONException | IOException | NullPointerException e) {
                             e.printStackTrace();
@@ -210,9 +211,7 @@ public class MyTripsFragment extends Fragment implements SwipeRefreshLayout.OnRe
 
     @Override
     public void onRefresh() {
-        mTripList.clear();
-        mMyTripsAdapter.notifyDataSetChanged();
         mytrip();
-        swipeRefreshLayout.setRefreshing(false);
+        swipeRefreshLayout.setRefreshing(true);
     }
 }

--- a/Android/app/src/main/java/io/github/project_travel_mate/mytrips/TripsListAdapter.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/mytrips/TripsListAdapter.java
@@ -32,8 +32,7 @@ class TripsListAdapter extends RecyclerView.Adapter<TripsListAdapter.TimelineVie
     private LayoutInflater mInflater;
     private static ClickListener mClickListener;
 
-    TripsListAdapter(Context context,
-                   List<Trip> trips) {
+    TripsListAdapter(List<Trip> trips) {
         this.mTrips = trips;
     }
 


### PR DESCRIPTION
## Description

This pull request fixes the issue where duplicate trips get added on swiping to refresh. The PR sets refreshing to true in onRefresh, and sets it to false in onResponse of the OkHttp Call. Also, it updates the adapter accordingly.

Fixes #502 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
