### PR TITLE
Added spinner to customize number of days in trends graph

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.airbnb.lottie.LottieAnimationView;
@@ -46,6 +47,7 @@ import java.util.Objects;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import butterknife.OnItemSelected;
 import io.github.project_travel_mate.R;
 import objects.ZoneName;
 import okhttp3.Call;
@@ -79,14 +81,20 @@ public class CurrencyActivity extends AppCompatActivity {
     TextView to_country_name;
     @BindView(R.id.graph)
     LineChart graph;
+    @BindView(R.id.chart_duration_spinner)
+    Spinner chart_duration_spinner;
 
 
     Boolean flag_check_first_item = false;
     Boolean flag_check_second_item = false;
+    Boolean flag_convert_pressed = false;
+
+
+
     int from_amount = 1;
     String first_country_short = "USD";
     String second_country_short = "INR";
-    private static final String GRAPH_LABEL_NAME = "Last 7 days currency rate trends";
+    String GRAPH_LABEL_NAME = "Last 7 days currency rate trends";
 
     private ProgressDialog mDialog;
     public static ArrayList<ZoneName> currences_names;
@@ -140,10 +148,13 @@ public class CurrencyActivity extends AppCompatActivity {
 
     @OnClick(R.id.button_convert)
     void onConvertclicked() {
+
         from_amount = Integer.parseInt(from_edittext.getText().toString());
         if (new Connection().isOnline()) {
             convertCurrency();
-            currencyRate();
+            int chartDays = getChartTimeInterval();
+            currencyRate(chartDays);
+            flag_convert_pressed = true;
             utils.Utils.hideKeyboard(this);
         } else {
             AlertDialog.Builder builder = new AlertDialog.Builder(CurrencyActivity.this);
@@ -154,11 +165,43 @@ public class CurrencyActivity extends AppCompatActivity {
         }
     }
 
+    @OnItemSelected(R.id.chart_duration_spinner)
+    void onChartDurationSpinnerClicked() {
+        if (flag_convert_pressed) {
+            onConvertclicked();
+            GRAPH_LABEL_NAME = "Last " + chart_duration_spinner.getSelectedItem() + " currency rate trends";
+        }
+    }
+
+
+
+    // Method to obtain value(last x number of days) to be passed to API
+    int getChartTimeInterval() {
+        switch (chart_duration_spinner.getSelectedItemPosition()) {
+            default:
+                return 6;
+            case 0:
+                return 6;
+            case 1:
+                return 30;
+            case 2:
+                return 60;
+            case 3:
+                return 180;
+            case 4:
+                return 364;
+
+        }
+    }
+
+
     void setupGraph(JSONArray currencyRateTrends) {
         if (currencyRateTrends == null || currencyRateTrends.length() == 0) {
             graph.setVisibility(View.GONE);
+            chart_duration_spinner.setVisibility(View.INVISIBLE);
         } else {
             graph.setVisibility(View.VISIBLE);
+            chart_duration_spinner.setVisibility(View.VISIBLE);
             graph.getXAxis().setEnabled(false);
             graph.getAxisLeft().setEnabled(false);
             graph.getAxisRight().setEnabled(false);
@@ -275,10 +318,10 @@ public class CurrencyActivity extends AppCompatActivity {
      * currency rate conversion
      * and set result to graph
      */
-    private void currencyRate() {
+    private void currencyRate(int totalDays) {
 
         String uri = API_LINK_V2 + "get-all-currency-rate/"
-                + DateUtils.getDate(6) + "/" + DateUtils.getDate(0) + "/"
+                + DateUtils.getDate(totalDays) + "/" + DateUtils.getDate(0) + "/"
                 + first_country_short.toLowerCase() + "/" + second_country_short.toLowerCase();
 
         mDialog.show();

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
@@ -167,6 +167,7 @@ public class CurrencyActivity extends AppCompatActivity {
 
     @OnItemSelected(R.id.chart_duration_spinner)
     void onChartDurationSpinnerClicked() {
+        // Flag is implemented here so that default behaviour of spinner's on item selected doesn't trigger when activity is first launched
         if (flag_convert_pressed) {
             onConvertclicked();
             GRAPH_LABEL_NAME = "Last " + chart_duration_spinner.getSelectedItem() + " currency rate trends";

--- a/Android/app/src/main/res/layout/activity_utilities_currency_converter.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_currency_converter.xml
@@ -176,6 +176,18 @@
             android:text="@string/convert"
             android:textColor="#fff" />
 
+        <Spinner
+            android:id="@+id/chart_duration_spinner"
+            android:layout_margin="10dp"
+            android:padding="20dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:entries="@array/time_series_array"
+            android:prompt="@string/time_series_prompt"
+            android:layout_below="@id/button_convert"
+            android:visibility="invisible"/>
+
 
         <com.github.mikephil.charting.charts.LineChart
             android:id="@+id/graph"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -333,4 +333,15 @@
     <string name="check_internet">Please check your internet connectivity</string>
     <string name="you_dont_have_trips">You don\'t have any upcoming trips. Click on + icon on bottom to add new trip!</string>
     <string name="your_past_trips">Your past trips</string>
+
+    <!-- Currency Convertor Chart Time-Series Spinner options -->
+    <string name="time_series_prompt">Time Interval</string>
+    <string-array name="time_series_array">
+        <item>7 Days</item>
+        <item>1 Month</item>
+        <item>2 Months</item>
+        <item>6 Months</item>
+        <item>1 Year</item>
+
+    </string-array>
 </resources>


### PR DESCRIPTION
## Description

Added Spinner to CurrencyActivity || navigation drawer -> utilities -> currency converter
Referring to issue #522 (Currency converter : Make number of days customizable in trends graph)
fixes #522

**Initial Screen**  
![init](https://user-images.githubusercontent.com/15249170/47306697-c3cc8d80-d65f-11e8-96cd-d0ab68c18d4b.PNG)

**Convert Button Pressed**
![convertpressed](https://user-images.githubusercontent.com/15249170/47306775-ed85b480-d65f-11e8-959d-fd94cdd2cca7.PNG)

**Dropdown button pressed**
![dropdownpressed](https://user-images.githubusercontent.com/15249170/47306782-f24a6880-d65f-11e8-8d26-3dad8f602dfc.PNG)

**1 Year selected**
![1 year selected](https://user-images.githubusercontent.com/15249170/47306792-f6768600-d65f-11e8-934d-0706f00cd98b.PNG)

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
