### PR TITLE
fixed forgot password ui issues

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/login/LoginActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/login/LoginActivity.java
@@ -213,7 +213,6 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                 emailString = mEmailForgotPassword.getText().toString();
                 if (validateEmail(emailString)) {
                     mBackToLogin.setVisibility(View.GONE);
-                    mResendCodeText.setVisibility(View.VISIBLE);
                     mLoginPresenter.ok_password_reset_request(emailString, mHandler);
                 }
                 break;
@@ -317,6 +316,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
 
     @Override
     public void openLogin() {
+        showMessage(getString(R.string.text_password_updated_alert));
         mForgotPasswordLayout.setVisibility(View.GONE);
         mNewPasswordLayout.setVisibility(View.GONE);
         sig.setVisibility(View.GONE);
@@ -376,7 +376,6 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
         if (validatePassword(newPassword)) {
             if (confirmNewPassword.equals(newPassword)) {
                 mLoginPresenter.ok_password_reset(email, mOtpCode, newPassword, mHandler);
-                showMessage(getString(R.string.text_password_updated_alert));
             }
         }
     }

--- a/Android/app/src/main/java/io/github/project_travel_mate/login/LoginPresenter.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/login/LoginPresenter.java
@@ -189,6 +189,7 @@ class LoginPresenter {
      */
     public void ok_password_reset_request(String email, Handler mHandler) {
         //TODO validate email address, verify if it's a registered user, send 4- digit otp to email
+        mHandler.post(() -> mView.showLoadingDialog());
         String uri = API_LINK_V2 + "forgot-password-email-code/" + email;
         //Set up client
         OkHttpClient client = new OkHttpClient();
@@ -201,7 +202,10 @@ class LoginPresenter {
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                mHandler.post(() -> mView.showError());
+                mHandler.post(() -> {
+                    mView.dismissLoadingDialog();
+                    mView.showError();
+                });
             }
 
             @Override
@@ -209,6 +213,7 @@ class LoginPresenter {
                 final String res = Objects.requireNonNull(response.body()).string();
 
                 mHandler.post(() -> {
+                    mView.dismissLoadingDialog();
                     if (response.isSuccessful()) {
                         mView.showMessage(res);
                         //if email is verified as a registered one
@@ -250,6 +255,7 @@ class LoginPresenter {
      */
     public void ok_password_reset(String email, String code, String newPassword, Handler mHandler) {
         //TODO update the password for the corresponding email address
+        mHandler.post(() -> mView.showLoadingDialog());
         String uri = API_LINK_V2 + "forgot-password-verify-code/" + email
                 + "/" + code + "/" + newPassword;
         //Set up client
@@ -262,7 +268,10 @@ class LoginPresenter {
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                mHandler.post(() -> mView.showError());
+                mHandler.post(() -> {
+                    mView.dismissLoadingDialog();
+                    mView.showError();
+                });
             }
 
             @Override
@@ -270,8 +279,8 @@ class LoginPresenter {
                 final String res = Objects.requireNonNull(response.body()).string();
 
                 mHandler.post(() -> {
+                    mView.dismissLoadingDialog();
                     if (response.isSuccessful()) {
-                        mView.showMessage("Password updated successfully");
                         //display the login UI to login with the new password
                         mView.openLogin();
                     } else if (response.code() == 400) {


### PR DESCRIPTION
## Description

Fixed forgot password ui issue.
1. Now user will see "Resend otp" only on the OTP screen and not on email screen. 
![removal of text_resend_code](https://user-images.githubusercontent.com/33592316/47600914-16060980-d9e6-11e8-81af-2f379def94c8.png)
2. Loader while validating email when user enters the email and press the button.
![loader while validating email](https://user-images.githubusercontent.com/33592316/47600926-3df56d00-d9e6-11e8-9f4f-08e6b35af55f.png)
3. Only one message is shown when the OTP is correct and user moves to login screen to login again with the new password. 
![one message only after reseting password](https://user-images.githubusercontent.com/33592316/47600934-5cf3ff00-d9e6-11e8-8fcf-c2c5e1d0157a.png)




Fixes #(issue)

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
