### PR TITLE
Fix 577 Snackbar is displayed for very long duration in my trips section

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/mytrips/MyTripsFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/mytrips/MyTripsFragment.java
@@ -194,7 +194,7 @@ public class MyTripsFragment extends Fragment implements SwipeRefreshLayout.OnRe
      */
     private void noResults() {
         TravelmateSnackbars.createSnackBar(mTripsView.findViewById(R.id.my_trips_frag), R.string.no_trips,
-                Snackbar.LENGTH_LONG).show();
+                Snackbar.LENGTH_SHORT).show();
         animationView.setAnimation(R.raw.empty_list);
         animationView.setVisibility(View.VISIBLE);
         animationView.playAnimation();


### PR DESCRIPTION
## Description

Snackbar duration is set to short

Fixes #577 


- [x] Bug fix (non-breaking change which fixes an issue)


Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
