### PR TITLE
Add "collapseMode - parallax" to "FAB - know_more"

### DIFF
--- a/Android/app/src/main/res/layout/activity_my_trip_info.xml
+++ b/Android/app/src/main/res/layout/activity_my_trip_info.xml
@@ -47,6 +47,7 @@
                 android:layout_gravity="end|bottom"
                 android:layout_margin="16dp"
                 android:src="@drawable/ic_location_city_black"
+                app:layout_collapseMode="parallax"
                 android:tint="@color/white" />
 
         </android.support.design.widget.CollapsingToolbarLayout>


### PR DESCRIPTION
## Description

This change prevents the "FloatingActionBar - know_more" from
covering the "share" & "menu" icons when collapsing.

![travel-mate-pr](https://user-images.githubusercontent.com/35611020/55817964-3240c300-5abb-11e9-90da-21cc21cf163f.gif)

Fixes #(issue)

Resolves #600

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
