### PR TITLE
Fixes #628 - Adding empty check to restaurant image url string in RestaurantDetailsActivity

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/RestaurantDetailsActivity.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/RestaurantDetailsActivity.kt
@@ -45,7 +45,9 @@ class RestaurantDetailsActivity : AppCompatActivity() {
     }
 
     private fun populateViews (restaurant: RestaurantDetails) {
-        Picasso.with(this).load(restaurant.featuredImage).into(image_view)
+        if (restaurant.featuredImage.trim().isNotEmpty()) {
+            Picasso.with(this).load(restaurant.featuredImage).into(image_view)
+        }
 
         address.text = getString(R.string.rest_address, restaurant.address)
         avg_cost.text = getString(R.string.avg_cost, restaurant.avgCost.toString())


### PR DESCRIPTION
## Description

Checking if the url string for a restaurant is empty before attempting to load the url with Picasso in RestaurantDetailsActivity.

Fixes #628 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
