### PR TITLE
fixed screen orientation in ShoppingCurrentCityActivity

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 


### PR DESCRIPTION
## Description

I fixed screen orientation for ShoppingCurrentCityActivity. I added method onSaveInstanceState where I save instances for listview and city name. I had to declare local variable mFeedItems, where I store originally feedItems, because I need to pass it to outState when activity is destroyed(screen orientation changes). In method onCreate I pass it back to variable, and I recreate view.

Fixes #632

## Type of change
Just put an x in the [] which are valid.
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x ] `./gradlew checkstyle`

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
