### PR TITLE
Fixes Issue #702

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
@@ -89,7 +89,6 @@ public class CurrencyActivity extends AppCompatActivity {
     Boolean flag_convert_pressed = false;
 
 
-
     int from_amount = 1;
     String first_country_short = "USD";
     String second_country_short = "INR";
@@ -173,7 +172,6 @@ public class CurrencyActivity extends AppCompatActivity {
             GRAPH_LABEL_NAME = "Last " + chart_duration_spinner.getSelectedItem() + " currency rate trends";
         }
     }
-
 
 
     // Method to obtain value(last x number of days) to be passed to API
@@ -446,5 +444,19 @@ public class CurrencyActivity extends AppCompatActivity {
             NetworkInfo info = cm != null ? cm.getActiveNetworkInfo() : null;
             return info != null && info.isConnectedOrConnecting();
         }
+    }
+
+    /**
+     * Error animation will be cancelled if user presses back while the animation is showing
+     */
+    @Override
+    public void onBackPressed() {
+        if (animationView != null) {
+            if (animationView.getVisibility() == View.VISIBLE) {
+                cancelAnimation();
+                return;
+            }
+        }
+        super.onBackPressed();
     }
 }


### PR DESCRIPTION
## Description

If the error animation is showing (i.e. Visible) onBackPressed() calls the cancelAnimation method which results in Currency Converter Activity not getting destroyed, and user is not required to do currency conversion from beginning as mentioned in #702 

Fixes #702

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- A JSONException was explicitly thrown to produce the error and check if everything is working as expected, the code worked as expected. 
Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
