### PR TITLE
#626-Wrap views under NestedScrollView to allow seeing full view in landscape

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/CurrencyActivity.java
@@ -65,7 +65,7 @@ public class CurrencyActivity extends AppCompatActivity {
     @BindView(R.id.animation_view)
     LottieAnimationView animationView;
     @BindView(R.id.actual_layout)
-    RelativeLayout actual_layout;
+    View actual_layout;
     @BindView(R.id.first_country_image)
     ImageView from_image;
     @BindView(R.id.second_country_flag)

--- a/Android/app/src/main/res/layout/activity_utilities_currency_converter.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_currency_converter.xml
@@ -1,202 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#fff"
-    android:orientation="vertical"
-    app:ignore="NamespaceTypo">
+  xmlns:app="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="#fff"
+  android:orientation="vertical"
+  app:ignore="NamespaceTypo">
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/animation_view"
-        android:layout_width="300dp"
-        android:layout_height="300dp"
-        android:layout_gravity="center"
-        app:lottie_autoPlay="true"
-        app:lottie_fileName="loading.json"
-        app:lottie_imageAssetsFolder="images"
-        app:lottie_loop="true" />
+  <com.airbnb.lottie.LottieAnimationView
+    android:id="@+id/animation_view"
+    android:layout_width="300dp"
+    android:layout_height="300dp"
+    android:layout_gravity="center"
+    app:lottie_autoPlay="true"
+    app:lottie_fileName="loading.json"
+    app:lottie_imageAssetsFolder="images"
+    app:lottie_loop="true" />
+
+  <android.support.v4.widget.NestedScrollView
+    android:id="@+id/actual_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <RelativeLayout
-        android:id="@+id/actual_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+      android:layout_width="match_parent"
+      android:layout_height="match_parent">
+
+      <RelativeLayout
+        android:id="@+id/layout_from"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <TextView
+          android:id="@+id/from"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="5sp"
+          android:layout_marginTop="5sp"
+          android:text="@string/from_text"
+          android:textColor="@color/green" />
+
 
         <RelativeLayout
-            android:id="@+id/layout_from"
-            android:layout_width="wrap_content"
+
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_below="@+id/from"
+          android:layout_marginTop="5sp"
+          android:background="#f5f5f5"
+          android:padding="10sp">
+
+
+          <RelativeLayout
+            android:id="@+id/from_field"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
+            <ImageView
+              android:id="@+id/first_country_image"
+              android:layout_width="50dp"
+              android:layout_height="40dp"
+              android:src="@drawable/us" />
+
             <TextView
-                android:id="@+id/from"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="5sp"
-                android:layout_marginTop="5sp"
-                android:text="@string/from_text"
-                android:textColor="@color/green" />
+              android:id="@+id/first_country_name"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_centerVertical="true"
+              android:layout_marginStart="19dp"
+              android:layout_marginLeft="19dp"
+              android:layout_toEndOf="@+id/first_country_image"
+              android:layout_toRightOf="@+id/first_country_image"
+              android:text="@string/usd_dollar"
+              android:textColor="#6e6e6e" />
+          </RelativeLayout>
 
-
-            <RelativeLayout
-
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/from"
-                android:layout_marginTop="5sp"
-                android:background="#f5f5f5"
-                android:padding="10sp">
-
-
-                <RelativeLayout
-                    android:id="@+id/from_field"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <ImageView
-                        android:id="@+id/first_country_image"
-                        android:layout_width="50dp"
-                        android:layout_height="40dp"
-                        android:src="@drawable/us" />
-
-                    <TextView
-                        android:id="@+id/first_country_name"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_centerVertical="true"
-                        android:layout_marginLeft="19dp"
-                        android:layout_marginStart="19dp"
-                        android:layout_toEndOf="@+id/first_country_image"
-                        android:layout_toRightOf="@+id/first_country_image"
-                        android:text="@string/usd_dollar"
-                        android:textColor="#6e6e6e" />
-                </RelativeLayout>
-
-                <EditText
-                    android:id="@+id/first_country_edittext"
-                    android:layout_width="80sp"
-                    android:layout_height="50sp"
-                    android:layout_alignBottom="@+id/from_field"
-                    android:layout_alignParentEnd="true"
-                    android:layout_alignParentRight="true"
-                    android:layout_marginEnd="17dp"
-                    android:layout_marginRight="17dp"
-                    android:background="@drawable/edit_txt_bg"
-                    android:ems="10"
-                    android:inputType="number"
-                    android:text="@string/usd_amount" />
-
-            </RelativeLayout>
+          <EditText
+            android:id="@+id/first_country_edittext"
+            android:layout_width="80sp"
+            android:layout_height="50sp"
+            android:layout_alignBottom="@+id/from_field"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_marginEnd="17dp"
+            android:layout_marginRight="17dp"
+            android:background="@drawable/edit_txt_bg"
+            android:ems="10"
+            android:inputType="number"
+            android:text="@string/usd_amount" />
 
         </RelativeLayout>
 
+      </RelativeLayout>
+
+
+      <RelativeLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="wrap_content"
+
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/layout_from">
+
+        <TextView
+          android:id="@+id/to"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="5sp"
+          android:layout_marginTop="5sp"
+          android:text="@string/to_text"
+          android:textColor="@color/green" />
 
         <RelativeLayout
-            android:id="@+id/relativeLayout"
-            android:layout_width="wrap_content"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_below="@+id/to"
+          android:layout_marginTop="5sp"
+          android:background="#f5f5f5"
+          android:padding="10sp">
 
+          <RelativeLayout
+            android:id="@+id/to_field"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/layout_from">
+            android:gravity="center">
+
+
+            <ImageView
+              android:id="@+id/second_country_flag"
+              android:layout_width="50dp"
+              android:layout_height="40dp"
+              android:src="@drawable/in" />
 
             <TextView
-                android:id="@+id/to"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="5sp"
-                android:layout_marginTop="5sp"
-                android:text="@string/to_text"
-                android:textColor="@color/green" />
-
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/to"
-                android:layout_marginTop="5sp"
-                android:background="#f5f5f5"
-                android:padding="10sp">
-
-                <RelativeLayout
-                    android:id="@+id/to_field"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center">
-
-
-                    <ImageView
-                        android:id="@+id/second_country_flag"
-                        android:layout_width="50dp"
-                        android:layout_height="40dp"
-                        android:src="@drawable/in" />
-
-                    <TextView
-                        android:id="@+id/second_country_name"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_centerVertical="true"
-                        android:layout_marginLeft="18dp"
-                        android:layout_marginStart="18dp"
-                        android:layout_toEndOf="@+id/second_country_flag"
-                        android:layout_toRightOf="@+id/second_country_flag"
-                        android:text="@string/inr"
-                        android:textColor="#6e6e6e" />
-                </RelativeLayout>
-
-            </RelativeLayout>
+              android:id="@+id/second_country_name"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_centerVertical="true"
+              android:layout_marginStart="18dp"
+              android:layout_marginLeft="18dp"
+              android:layout_toEndOf="@+id/second_country_flag"
+              android:layout_toRightOf="@+id/second_country_flag"
+              android:text="@string/inr"
+              android:textColor="#6e6e6e" />
+          </RelativeLayout>
 
         </RelativeLayout>
 
-        <RelativeLayout
-            android:id="@+id/relativeLayout2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/relativeLayout"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="16dp"
-            android:background="#f5f5f5"
-            android:padding="16dp">
+      </RelativeLayout>
 
-            <TextView
-                android:id="@+id/text_result"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:text="@string/output_0"
-                android:textColor="@color/green"
-                android:textSize="32sp" />
+      <RelativeLayout
+        android:id="@+id/relativeLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/relativeLayout"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:background="#f5f5f5"
+        android:padding="16dp">
 
-        </RelativeLayout>
+        <TextView
+          android:id="@+id/text_result"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerInParent="true"
+          android:text="@string/output_0"
+          android:textColor="@color/green"
+          android:textSize="32sp" />
 
-        <Button
-            android:id="@+id/button_convert"
-            android:layout_width="150dp"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/relativeLayout2"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="32dp"
-            android:background="@color/green"
-            android:text="@string/convert"
-            android:textColor="#fff" />
+      </RelativeLayout>
 
-        <Spinner
-            android:id="@+id/chart_duration_spinner"
-            android:layout_margin="10dp"
-            android:padding="20dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:entries="@array/time_series_array"
-            android:prompt="@string/time_series_prompt"
-            android:layout_below="@id/button_convert"
-            android:visibility="invisible"/>
+      <Button
+        android:id="@+id/button_convert"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/relativeLayout2"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="32dp"
+        android:background="@color/green"
+        android:text="@string/convert"
+        android:textColor="#fff" />
+
+      <Spinner
+        android:id="@+id/chart_duration_spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/button_convert"
+        android:layout_centerHorizontal="true"
+        android:layout_margin="10dp"
+        android:entries="@array/time_series_array"
+        android:padding="20dp"
+        android:prompt="@string/time_series_prompt"
+        android:visibility="invisible" />
 
 
-        <com.github.mikephil.charting.charts.LineChart
-            android:id="@+id/graph"
-            android:layout_width="match_parent"
-            android:layout_height="120dp"
-            android:layout_alignParentBottom="true"
-            android:layout_margin="16dp"
-            android:visibility="gone" />
+      <com.github.mikephil.charting.charts.LineChart
+        android:id="@+id/graph"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:layout_below="@id/chart_duration_spinner"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="16dp"
+        android:visibility="gone" />
 
     </RelativeLayout>
+
+  </android.support.v4.widget.NestedScrollView>
 
 </RelativeLayout>


### PR DESCRIPTION
## Description

I tried with `ConstraintLayout` but it doesn't work that well, and still see some issue in lower-dpi and small screen sizes. I decided to wrap the whole view under `NestedScrollView` so it can still be scrollable even when the button got pushed out of screen.

Also accommodate this change by changing ButterKnife Binding inside `CurrencyActivity`, specifically changing type of `R.id.actual_layout` to `View` instead of `RelativeLayout`. I think this is better approach as well since the best practice is to make the binding as generic as possible. For example, if you don't need `RelativeLayout` specific functions, then it can be used as `View` or `ViewGroup`. This allows you to update the layout easily, say in future, you want it to be `LinearLayout`, you don't need to touch the actual implementation code.

Fixes #626 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
