### PR TITLE
Add black contrast to the slider

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/CityImageSliderAdapter.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/destinations/description/CityImageSliderAdapter.java
@@ -2,6 +2,7 @@ package io.github.project_travel_mate.destinations.description;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.support.annotation.NonNull;
 import android.support.v4.view.PagerAdapter;
 import android.view.View;
@@ -51,6 +52,8 @@ public class CityImageSliderAdapter extends PagerAdapter {
                     mImagesArray.get(position), mCityName);
             mContext.startActivity(fullScreenIntent);
         });
+        imageView.setBackgroundColor(Color.TRANSPARENT);
+        imageView.setAlpha(0.6f);
         return imageView;
     }
 

--- a/Android/app/src/main/res/layout/activity_city_info.xml
+++ b/Android/app/src/main/res/layout/activity_city_info.xml
@@ -30,7 +30,7 @@
                 android:layout_height="230dp"
                 android:contentDescription="@string/empty_description"
                 android:scaleType="centerCrop"
-                android:background="@android:color/transparent"
+                android:background="@android:color/black"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior"
                 app:layout_collapseMode="parallax" />
 


### PR DESCRIPTION
## Description
Add black contrast to images in slider to fix city name when background is white or default image

## Screenshots.
![device-2019-10-13-213456](https://user-images.githubusercontent.com/23631699/66721034-be34fe00-ee02-11e9-9358-accca63f43e6.png)

Fixes #748 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
