### PR TITLE
Fixed an issue where the `forgot_password` textview would be pushed off the screen by the `signup` textview when in landscape.

### DIFF
--- a/Android/app/src/main/res/layout/activity_login.xml
+++ b/Android/app/src/main/res/layout/activity_login.xml
@@ -437,32 +437,37 @@
                         android:textColor="@color/white" />
                 </LinearLayout>
 
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" >
+
+                    <TextView
+                        android:id="@+id/forgot_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="start"
+                        android:padding="8dp"
+                        android:text="@string/text_forgot_password"
+                        android:layout_gravity="bottom"
+                        android:textAlignment="center"
+                        android:textColor="@color/white" />
+
+                    <TextView
+                        android:id="@+id/resend_code"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="start"
+                        android:padding="8dp"
+                        android:visibility="gone"
+                        android:text="@string/text_resend_code"
+                        android:layout_gravity="bottom"
+                        android:textAlignment="center"
+                        android:textColor="@color/white" />
+
+                </LinearLayout>
 
             </LinearLayout>
-
-            <TextView
-                android:id="@+id/forgot_password"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="start"
-                android:padding="8dp"
-                android:text="@string/text_forgot_password"
-                android:layout_gravity="bottom"
-                android:textAlignment="center"
-                android:textColor="@color/white" />
-
-            <TextView
-                android:id="@+id/resend_code"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="start"
-                android:padding="8dp"
-                android:visibility="gone"
-                android:text="@string/text_resend_code"
-                android:layout_gravity="bottom"
-                android:textAlignment="center"
-                android:textColor="@color/white" />
-
 
         </FrameLayout>
     </ScrollView>


### PR DESCRIPTION
Resolves #654 




## Description

Adjusted the `forgot_password` text to appropriately align below the `sign up` text. Before it would be squashed when in landscape on some devices.

<img width="611" alt="Screen Shot 2019-10-14 at 13 23 09" src="https://user-images.githubusercontent.com/6380898/66729381-05180780-ee86-11e9-8eef-91c42ff3b4b6.png">

Fixes #(issue)

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
