### PR TITLE
ProfileActivity convert default status from text to hint

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -166,7 +166,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
                     mSharedPreferences.getString(USER_EMAIL, null),
                     mSharedPreferences.getString(USER_IMAGE, null),
                     mSharedPreferences.getString(USER_DATE_JOINED, null),
-                    mSharedPreferences.getString(USER_STATUS, getString(R.string.default_status)));
+                    mSharedPreferences.getString(USER_STATUS, null));
 
         } else {
             editDisplayName.setVisibility(View.INVISIBLE);
@@ -518,10 +518,6 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
                             Long dateTime = rfc3339ToMills(dateJoined);
                             String date = getDate(dateTime);
 
-                            if (status == null || Objects.equals(status, "null")) {
-
-                                status = getString(R.string.default_status);
-                            }
                             fillProfileInfo(fullName, userName, imageURL, date, status);
 
                             mIsVerified = verified;
@@ -619,7 +615,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
                     });
                 }
             });
-        } catch (StringIndexOutOfBoundsException e ) {
+        } catch (StringIndexOutOfBoundsException e) {
             displayName.setVisibility(View.VISIBLE);
             nameProgressBar.setVisibility(View.INVISIBLE);
             Toast.makeText(getApplicationContext(), "Introduce atleast two names.", Toast.LENGTH_LONG).show();
@@ -643,7 +639,6 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         mUserStatus = String.valueOf(displayStatus.getText());
         if (mUserStatus.equals("")) {
             uri = API_LINK_V2 + "remove-user-status";
-            mUserStatus = getString(R.string.default_status);
 
             request = new Request.Builder()
                     .header("Authorization", "Token " + mToken)
@@ -716,9 +711,10 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         Picasso.with(ProfileActivity.this).load(imageURL).placeholder(R.drawable.default_user_icon)
                 .error(R.drawable.default_user_icon).into(displayImage);
         setTitle(fullName);
-        if (status.equals("null"))
-            status = getString(R.string.default_status);
-        displayStatus.setText(status);
+
+        if (status != null && !status.equals("null")) {
+            displayStatus.setText(status);
+        }
     }
 
     /**

--- a/Android/app/src/main/res/layout/activity_profile.xml
+++ b/Android/app/src/main/res/layout/activity_profile.xml
@@ -93,7 +93,7 @@
             android:inputType="textMultiLine"
             android:maxLength="100"
             android:padding="4dp"
-            android:text="@string/default_status"
+            android:hint="@string/default_status"
             android:textColor="@color/dark_grey"
             android:textSize="18sp"
             app:layout_constraintEnd_toStartOf="@id/ib_edit_display_status"


### PR DESCRIPTION
## Description

Show Default Status as hint in ProfileActivity to make easy to new user to add status without delete the text in first time and show hint when user remove old status

## Screenshot
![screenshot](https://user-images.githubusercontent.com/23631699/67032176-57ba2380-f113-11e9-9387-626730ea731e.PNG)

fixes #761 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
