### PR TITLE
Fix click item on City in FavouriteCitiesFragment and fix position in FlipViewPager

### DIFF
--- a/Android/app/src/main/java/flipviewpager/view/FlipViewPager.java
+++ b/Android/app/src/main/java/flipviewpager/view/FlipViewPager.java
@@ -341,7 +341,7 @@ public class FlipViewPager extends FrameLayout {
                             if (mCurrentPageIndex == 1 && isLeftClicked(ev)) {
                                 clickListener.onItemClick(null, this, mRow * 2, -1);
                             } else if (mCurrentPageIndex == 1 && isRightClicked(ev) && mMaxItems > (mRow * 2))
-                                clickListener.onItemClick(null, this, mRow * 2, -1);
+                                clickListener.onItemClick(null, this, mRow * 2 + 1, -1);
                         }
                         return false;
                     }

--- a/Android/app/src/main/java/io/github/project_travel_mate/destinations/CityAdapter.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/destinations/CityAdapter.java
@@ -55,17 +55,6 @@ class CityAdapter extends BaseFlipAdapter<City> {
         }
         infoHolder = new CitiesInfoHolder(holder.infoPage);
 
-        holder.mLeftView.setOnClickListener(v -> {
-            Intent intent = FinalCityInfoActivity.getStartIntent(mContext, city1);
-            mContext.startActivity(intent);
-
-        });
-        holder.mRightView.setOnClickListener(v -> {
-            Intent intent = FinalCityInfoActivity.getStartIntent(mContext, city2);
-            mContext.startActivity(intent);
-
-        });
-
         switch (position) {
             case 1:
                 Picasso.with(mContext).

--- a/Android/app/src/main/java/io/github/project_travel_mate/favourite/FavouriteCitiesFragment.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/favourite/FavouriteCitiesFragment.java
@@ -1,5 +1,6 @@
 package io.github.project_travel_mate.favourite;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -21,6 +22,7 @@ import butterknife.ButterKnife;
 import database.AppDataBase;
 import flipviewpager.utils.FlipSettings;
 import io.github.project_travel_mate.R;
+import io.github.project_travel_mate.destinations.description.FinalCityInfoActivity;
 import objects.City;
 
 public class FavouriteCitiesFragment extends Fragment {
@@ -72,8 +74,11 @@ public class FavouriteCitiesFragment extends Fragment {
 
         animationView.setVisibility(View.GONE);
         fav_cities_lv.setAdapter(mFavouriteCitiesAdapter);
-
-
+        fav_cities_lv.setOnItemClickListener((parent, mView, position, id1) -> {
+            City city = (City) fav_cities_lv.getAdapter().getItem(position);
+            Intent intent = FinalCityInfoActivity.getStartIntent(getActivity(), city);
+            startActivity(intent);
+        });
     }
 
     /**
@@ -84,5 +89,4 @@ public class FavouriteCitiesFragment extends Fragment {
         animationView.setAnimation(R.raw.empty_list);
         animationView.playAnimation();
     }
-
 }


### PR DESCRIPTION
## Description
- Add onClickListener to city in FavouriteCitiesFragment  to open CityInfo
- Remove listeners for left and right layout because it open city directly when click or touch with move
- Fix position in FlipViewPager to make user open Right city when click on it not Left City

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
