### PR TITLE
#736-Weather forecast drawables shouldn't show up in "unused resources"

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -13,6 +13,13 @@ android {
         versionName "5.6.2"
     }
 
+    lintOptions {
+        disable 'InvalidPackage'
+        abortOnError false
+        absolutePaths false
+        lintConfig file('lint.xml')
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/Android/app/lint.xml
+++ b/Android/app/lint.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="UnusedResources">
+        <ignore path="**/wi_day_cloudy.xml" />
+        <ignore path="**/wi_day_cloudy_gusts.xml" />
+        <ignore path="**/wi_day_fog.xml" />
+        <ignore path="**/wi_day_hail.xml" />
+        <ignore path="**/wi_day_haze.xml" />
+        <ignore path="**/wi_day_rain.xml" />
+        <ignore path="**/wi_day_rain_mix.xml" />
+        <ignore path="**/wi_day_showers.xml" />
+        <ignore path="**/wi_day_sleet.xml" />
+        <ignore path="**/wi_day_snow.xml" />
+        <ignore path="**/wi_day_sprinkle.xml" />
+        <ignore path="**/wi_day_storm_showers.xml" />
+        <ignore path="**/wi_day_sunny.xml" />
+        <ignore path="**/wi_day_thunderstorm.xml" />
+        <ignore path="**/wi_day_windy.xml" />
+        <ignore path="**/wi_night_clear.xml" />
+        <ignore path="**/wi_night_cloudy.xml" />
+        <ignore path="**/wi_night_cloudy_gusts.xml" />
+        <ignore path="**/wi_night_fog.xml" />
+        <ignore path="**/wi_night_hail.xml" />
+        <ignore path="**/wi_night_rain.xml" />
+        <ignore path="**/wi_night_rain_mix.xml" />
+        <ignore path="**/wi_night_showers.xml" />
+        <ignore path="**/wi_night_sleet.xml" />
+        <ignore path="**/wi_night_snow.xml" />
+        <ignore path="**/wi_night_sprinkle.xml" />
+        <ignore path="**/wi_night_storm_showers.xml" />
+        <ignore path="**/wi_night_sunny.xml" />
+        <ignore path="**/wi_night_thunderstorm.xml" />
+
+    </issue>
+</lint>


### PR DESCRIPTION
## Description

I added lint.xml file to ignore all of the weather drawables.  Now, the weather drawables won't show up if we check for unused drawables in IDE.

Fixes #736 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
