### PR TITLE
Make ProfileActivity work in offline mode

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -171,6 +171,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         } else {
             editDisplayName.setVisibility(View.INVISIBLE);
             updateOptionsMenu();
+            updateOptionsMenu();
         }
 
         isVerified.setOnClickListener(view -> {
@@ -513,7 +514,6 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
                             String dateJoined = object.getString("date_joined");
                             String status = object.getString("status");
                             boolean verified = object.getBoolean("is_verified");
-                            new User(userName, firstName, lastName, id, imageURL, dateJoined, status);
                             String fullName = firstName + " " + lastName;
                             Long dateTime = rfc3339ToMills(dateJoined);
                             String date = getDate(dateTime);

--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -68,6 +68,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import utils.CircleImageView;
 import utils.TravelmateSnackbars;
+import utils.Utils;
 
 import static android.view.View.GONE;
 import static com.google.android.flexbox.FlexDirection.ROW;
@@ -156,23 +157,25 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
 
         Intent intent = getIntent();
         String id = intent.getStringExtra(OTHER_USER_ID);
-        getTravelledCities();
-        getUserDetails(id);
-        Objects.requireNonNull(getSupportActionBar()).setHomeButtonEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        if (id == null) {
-            fillProfileInfo(mSharedPreferences.getString(USER_NAME, null),
-                    mSharedPreferences.getString(USER_EMAIL, null),
-                    mSharedPreferences.getString(USER_IMAGE, null),
-                    mSharedPreferences.getString(USER_DATE_JOINED, null),
-                    mSharedPreferences.getString(USER_STATUS, null));
-
-        } else {
+        if (id != null) {
             editDisplayName.setVisibility(View.INVISIBLE);
             updateOptionsMenu();
-            updateOptionsMenu();
         }
+
+        boolean isNetworkConnected = Utils.isNetworkConnected(this);
+        if (isNetworkConnected) {
+            getUserDetails(id);
+            getTravelledCities();
+        } else {
+            fillProfileOffline(mSharedPreferences.getString(USER_NAME, null),
+                    mSharedPreferences.getString(USER_EMAIL, null),
+                    mSharedPreferences.getString(USER_DATE_JOINED, null),
+                    mSharedPreferences.getString(USER_STATUS, null));
+        }
+
+        Objects.requireNonNull(getSupportActionBar()).setHomeButtonEnabled(true);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         isVerified.setOnClickListener(view -> {
             AlertDialog.Builder builder = new AlertDialog.Builder(ProfileActivity.this);
@@ -713,6 +716,28 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         Picasso.with(ProfileActivity.this).load(imageURL).placeholder(R.drawable.default_user_icon)
                 .error(R.drawable.default_user_icon).into(displayImage);
         setTitle(fullName);
+
+        if (status != null && !status.equals("null")) {
+            displayStatus.setText(status);
+        }
+    }
+
+    private void fillProfileOffline(String name, String email,
+                                    String dateJoined, String status) {
+        //Change Views Visibility in offline mode
+        displayImage.setVisibility(View.VISIBLE);
+        editDisplayName.setVisibility(View.INVISIBLE);
+        editDisplayStatus.setVisibility(View.INVISIBLE);
+        changeImage.setVisibility(View.INVISIBLE);
+
+        displayName.setText(name);
+        emailId.setText(email);
+        joiningDate.setText(String.format(getString(R.string.text_joining_date), dateJoined));
+
+        Picasso.with(ProfileActivity.this)
+                .load(R.drawable.default_user_icon)
+                .placeholder(R.drawable.default_user_icon)
+                .into(displayImage);
 
         if (status != null && !status.equals("null")) {
             displayStatus.setText(status);

--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -531,12 +531,14 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
                             }
 
                             if (userId == null) {
-                                mSharedPreferences.edit().putString(USER_NAME, fullName).apply();
-                                mSharedPreferences.edit().putString(USER_EMAIL, userName).apply();
-                                mSharedPreferences.edit().putString(USER_DATE_JOINED, date).apply();
-                                mSharedPreferences.edit().putString(USER_IMAGE, imageURL).apply();
-                                mSharedPreferences.edit().putString(USER_ID, String.valueOf(id)).apply();
-                                mSharedPreferences.edit().putString(USER_STATUS, status).apply();
+                                SharedPreferences.Editor editor = mSharedPreferences.edit();
+                                editor.putString(USER_NAME, fullName);
+                                editor.putString(USER_EMAIL, userName);
+                                editor.putString(USER_DATE_JOINED, date);
+                                editor.putString(USER_IMAGE, imageURL);
+                                editor.putString(USER_ID, String.valueOf(id));
+                                editor.putString(USER_STATUS, status);
+                                editor.apply();
                             } else {
                                 updateOptionsMenu();
                             }

--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -168,10 +168,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
             getUserDetails(id);
             getTravelledCities();
         } else {
-            fillProfileOffline(mSharedPreferences.getString(USER_NAME, null),
-                    mSharedPreferences.getString(USER_EMAIL, null),
-                    mSharedPreferences.getString(USER_DATE_JOINED, null),
-                    mSharedPreferences.getString(USER_STATUS, null));
+            fillProfileOffline();
         }
 
         Objects.requireNonNull(getSupportActionBar()).setHomeButtonEnabled(true);
@@ -722,8 +719,16 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         }
     }
 
-    private void fillProfileOffline(String name, String email,
-                                    String dateJoined, String status) {
+    /**
+     * Fill profile with user information from SharedPreferences when user is offline
+     */
+    private void fillProfileOffline() {
+        //Get user information from SharedPreferences
+        String name = mSharedPreferences.getString(USER_NAME, null);
+        String email = mSharedPreferences.getString(USER_EMAIL, null);
+        String dateJoined = mSharedPreferences.getString(USER_DATE_JOINED, null);
+        String status = mSharedPreferences.getString(USER_STATUS, null);
+
         //Change Views Visibility in offline mode
         displayImage.setVisibility(View.VISIBLE);
         editDisplayName.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
## Description
- Check user Internet state and show user information from SharedPreferences if user is offline
- Make SharedPreferences update file once not for every addition it will work in 1ms not 3ms in old code
- Delete unused User class instance

# Screenshot Before
![offline_before](https://user-images.githubusercontent.com/23631699/67525509-290ff000-f6b3-11e9-8e32-31a9b9cc3151.PNG)

# Screenshot After
![Offline_after](https://user-images.githubusercontent.com/23631699/67525512-2b724a00-f6b3-11e9-83c6-b6064bdb3995.PNG)

Fixes #775 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
