### PR TITLE
#737 - World clock UI update

### DIFF
--- a/Android/app/src/main/java/adapters/TimezoneAdapter.java
+++ b/Android/app/src/main/java/adapters/TimezoneAdapter.java
@@ -1,0 +1,100 @@
+package adapters;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Filter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import io.github.project_travel_mate.R;
+import io.github.project_travel_mate.utilities.helper.FlagHelper;
+
+public class TimezoneAdapter extends ArrayAdapter<String> {
+
+    private List<String> mTimezones;
+    private final Filter mFilter;
+
+    public TimezoneAdapter(@NonNull Context context, @NonNull List<String> objects) {
+        super(context, 0, new ArrayList<>(objects));
+        this.mTimezones = new ArrayList<>(objects);
+        this.mFilter = new TimezoneFilter();
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        View view = convertView;
+        if (view == null) {
+            LayoutInflater vi = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            view = vi.inflate(R.layout.item_timezone, parent, false);
+        }
+
+        String timezone = this.getItem(position);
+        if (timezone == null) {
+            return view;
+        }
+
+        ViewHolder viewHolder = new ViewHolder(view);
+        viewHolder.tvTimezoneLabel.setText(timezone);
+
+        String escapedTimezone = timezone.contains("/") ? timezone.split("/")[1] : timezone;
+        viewHolder.ivTimezoneFlag.setImageResource(FlagHelper.Companion.retrieveFlagDrawable(escapedTimezone));
+
+        return view;
+    }
+
+    @Override
+    public Filter getFilter() {
+        return this.mFilter;
+    }
+
+    class TimezoneFilter extends android.widget.Filter {
+        @Override
+        protected Filter.FilterResults performFiltering(CharSequence constraint) {
+            List<String> matchingTimezones = new ArrayList<>();
+            if (TextUtils.isEmpty(constraint)) {
+                matchingTimezones.addAll(TimezoneAdapter.this.mTimezones);
+            } else {
+                String pattern = constraint.toString().toLowerCase().trim();
+                for (String timezone : TimezoneAdapter.this.mTimezones) {
+                    if (timezone.toLowerCase().contains(pattern)) {
+                        matchingTimezones.add(timezone);
+                    }
+                }
+            }
+
+            Filter.FilterResults filterResults = new Filter.FilterResults();
+            filterResults.values = matchingTimezones;
+            filterResults.count = matchingTimezones.size();
+
+            return filterResults;
+        }
+
+        @Override
+        protected void publishResults(CharSequence constraint, FilterResults results) {
+            TimezoneAdapter.this.clear();
+            TimezoneAdapter.this.addAll((List) results.values);
+            TimezoneAdapter.this.notifyDataSetChanged();
+        }
+    }
+    class ViewHolder {
+        @BindView(R.id.tvTimezoneLabel)
+        TextView tvTimezoneLabel;
+
+        @BindView(R.id.ivTimezoneFlag)
+        ImageView ivTimezoneFlag;
+
+        public ViewHolder(@NonNull View itemView) {
+            ButterKnife.bind(this, itemView);
+        }
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
@@ -2,19 +2,17 @@ package io.github.project_travel_mate.utilities;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
 import android.widget.AutoCompleteTextView;
 import android.widget.TextClock;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;
 
@@ -25,8 +23,6 @@ import io.github.project_travel_mate.R;
 
 public class WorldClockActivity extends AppCompatActivity {
 
-    private static final String DEFAULT_TIME_ZONE_KEY = "defaultTimeZone";
-
     @BindView(R.id.clock_analog)
     CustomAnalogClock mAnalogClock;
 
@@ -36,9 +32,9 @@ public class WorldClockActivity extends AppCompatActivity {
     @BindView(R.id.actvTimezone)
     AutoCompleteTextView mAutoCompleteTextViewTimezone;
 
-    private TimezoneAdapter mAdapter;
-    private long mMiliSeconds;
-    private Calendar mCurrent;
+    public static Intent getStartIntent(Context context) {
+        return new Intent(context, WorldClockActivity.class);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -47,16 +43,17 @@ public class WorldClockActivity extends AppCompatActivity {
         ButterKnife.bind(this);
         setTitle(R.string.text_clock);
 
-        mTextClock = findViewById(R.id.clock_digital);
-        mAnalogClock = findViewById(R.id.clock_analog);
+        // AutoCompleteTextView initialization
+        TimezoneAdapter mAdapter = new TimezoneAdapter(this, Arrays.asList(TimeZone.getAvailableIDs()));
+        this.mAutoCompleteTextViewTimezone.setAdapter(mAdapter);
+        this.mAutoCompleteTextViewTimezone.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                WorldClockActivity.this.onItemAutocompleteItemSelected();
+            }
+        });
 
-        String[] idArray = TimeZone.getAvailableIDs();
-        this.mAdapter = new TimezoneAdapter(this, Arrays.asList(idArray));
-        this.mAutoCompleteTextViewTimezone.setAdapter(this.mAdapter);
-
-        /**
-         * Analog Clock Initialization
-         */
+        // Analog Clock Initialization
         mAnalogClock.init(WorldClockActivity.this, R.drawable.clock_face,
                 R.drawable.hours_hand, R.drawable.minutes_hand,
                 0, false, false);
@@ -64,19 +61,14 @@ public class WorldClockActivity extends AppCompatActivity {
         mAnalogClock.setScale(1f);
         // analog clock size
 
-        getGMTTime();
-        // get time from selected time zone
+        // Initialize data with default timezone
+        this.setSelectedText(TimeZone.getDefault());
+
 
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
 
     }
-
-
-    public static Intent getStartIntent(Context context) {
-        return new Intent(context, WorldClockActivity.class);
-    }
-
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -87,47 +79,25 @@ public class WorldClockActivity extends AppCompatActivity {
     }
 
     /**
-     * This function gets GMT time and also performs time calculation according to time zone.
-     */
-    private void getGMTTime() {
-        mCurrent = Calendar.getInstance();
-        mCurrent.add(Calendar.HOUR, -2);
-        mMiliSeconds = mCurrent.getTimeInMillis();
-        TimeZone tzCurrent = mCurrent.getTimeZone();
-        int offset = tzCurrent.getRawOffset();
-        if (tzCurrent.inDaylightTime(new Date())) {
-            offset = offset + tzCurrent.getDSTSavings();
-        }
-        mMiliSeconds = mMiliSeconds - offset;
-    }
-
-    /**
-     * This function saves the user selected time zone
-     *
-     * @param key
-     * @param value
-     */
-    private void saveTimeZonePrefs(String key, String value) {
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
-        settings.edit().putString(key, value).apply();
-    }
-
-    /**
      * This function gets the time from the time zone that user have chosen.
      *
      * @param timezone
      */
     private void setSelectedText(TimeZone timezone) {
-        mMiliSeconds = mMiliSeconds + timezone.getRawOffset();
-        mTextClock.setTimeZone(timezone.getID());
+        this.mTextClock.setTimeZone(timezone.getID());
+
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.HOUR, -2);
-        mAnalogClock.setTime(calendar);
-        mAnalogClock.setTimezone(timezone);
-        saveTimeZonePrefs(DEFAULT_TIME_ZONE_KEY, timezone.getID());
-        mTextClock.setFormat12Hour("hh:mm:ss a"); //for 12 hour format
-        mTextClock.setFormat24Hour("k:mm:ss"); // for 24 hour format
-        mMiliSeconds = 0;
+        this.mAnalogClock.setTime(calendar);
+        this.mAnalogClock.setTimezone(timezone);
+    }
+
+    /**
+     * Method triggered when the user selects
+     * a timezone from the list
+     */
+    private void onItemAutocompleteItemSelected() {
+        this.setSelectedText(TimeZone.getTimeZone(this.mAutoCompleteTextViewTimezone.getText().toString()));
     }
 
 }

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
@@ -20,6 +20,7 @@ import adapters.TimezoneAdapter;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.github.project_travel_mate.R;
+import io.github.project_travel_mate.utilities.helper.KeyboardHelper;
 
 public class WorldClockActivity extends AppCompatActivity {
 
@@ -97,6 +98,7 @@ public class WorldClockActivity extends AppCompatActivity {
      * a timezone from the list
      */
     private void onItemAutocompleteItemSelected() {
+        KeyboardHelper.Companion.hideKeyboard(this);
         this.setSelectedText(TimeZone.getTimeZone(this.mAutoCompleteTextViewTimezone.getText().toString()));
     }
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/WorldClockActivity.java
@@ -8,28 +8,36 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.Spinner;
+import android.widget.AutoCompleteTextView;
 import android.widget.TextClock;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
 import java.util.TimeZone;
 
+import adapters.TimezoneAdapter;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.github.project_travel_mate.R;
 
 public class WorldClockActivity extends AppCompatActivity {
 
-    private CustomAnalogClock mAnalogClock;
     private static final String DEFAULT_TIME_ZONE_KEY = "defaultTimeZone";
-    private TextClock mTextClock;
+
+    @BindView(R.id.clock_analog)
+    CustomAnalogClock mAnalogClock;
+
+    @BindView(R.id.clock_digital)
+    TextClock mTextClock;
+
+    @BindView(R.id.actvTimezone)
+    AutoCompleteTextView mAutoCompleteTextViewTimezone;
+
+    private TimezoneAdapter mAdapter;
     private long mMiliSeconds;
-    private ArrayAdapter<String> mIdAdapter;
-    private Spinner mTimeZoneChooser;
     private Calendar mCurrent;
 
     @Override
@@ -41,13 +49,10 @@ public class WorldClockActivity extends AppCompatActivity {
 
         mTextClock = findViewById(R.id.clock_digital);
         mAnalogClock = findViewById(R.id.clock_analog);
-        mTimeZoneChooser = findViewById(R.id.availableID); // choosing time zone
 
         String[] idArray = TimeZone.getAvailableIDs();
-        mIdAdapter = new ArrayAdapter<>(this,
-                android.R.layout.simple_spinner_item, idArray);
-        mIdAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        mTimeZoneChooser.setAdapter(mIdAdapter);
+        this.mAdapter = new TimezoneAdapter(this, Arrays.asList(idArray));
+        this.mAutoCompleteTextViewTimezone.setAdapter(this.mAdapter);
 
         /**
          * Analog Clock Initialization
@@ -62,22 +67,6 @@ public class WorldClockActivity extends AppCompatActivity {
         getGMTTime();
         // get time from selected time zone
 
-        mTimeZoneChooser.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent,
-                                       View view, int position, long id) {
-                getGMTTime();
-                String selectedId = (String) (parent.getItemAtPosition(position));
-                TimeZone timezone = TimeZone.getTimeZone(selectedId);
-                setSelectedText(timezone);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> arg0) {
-
-            }
-        });
-
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
 
@@ -85,15 +74,15 @@ public class WorldClockActivity extends AppCompatActivity {
 
 
     public static Intent getStartIntent(Context context) {
-        Intent intent = new Intent(context, WorldClockActivity.class);
-        return intent;
+        return new Intent(context, WorldClockActivity.class);
     }
 
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home)
+        if (item.getItemId() == android.R.id.home) {
             finish();
+        }
         return super.onOptionsItemSelected(item);
     }
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/helper/FlagHelper.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/helper/FlagHelper.kt
@@ -1,0 +1,12 @@
+package io.github.project_travel_mate.utilities.helper
+
+import com.blongho.country_data.Country
+import com.blongho.country_data.World
+
+class FlagHelper {
+    companion object {
+        fun retrieveFlagDrawable(country: String) : Int {
+            return World.getCountryFrom(country).flagResource
+        }
+    }
+}

--- a/Android/app/src/main/java/io/github/project_travel_mate/utilities/helper/KeyboardHelper.kt
+++ b/Android/app/src/main/java/io/github/project_travel_mate/utilities/helper/KeyboardHelper.kt
@@ -1,0 +1,16 @@
+package io.github.project_travel_mate.utilities.helper
+
+import android.app.Activity
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+
+class KeyboardHelper {
+    companion object {
+        fun hideKeyboard(activity: Activity) {
+            val imm = activity.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+            val view = activity.currentFocus ?: View(activity)
+            imm.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
+}

--- a/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
@@ -17,17 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <TextView
-                android:id="@+id/tvTimeZone"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/select_timezone"
-                android:textColor="@color/black"
-                android:textSize="24sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
             <AutoCompleteTextView
                 android:id="@+id/actvTimezone"
                 android:layout_width="0dp"
@@ -37,7 +26,7 @@
                 android:hint="@string/select_timezone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tvTimeZone" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <io.github.project_travel_mate.utilities.CustomAnalogClock
                 android:id="@+id/clock_analog"

--- a/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
@@ -28,22 +28,16 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <RelativeLayout
-                android:id="@+id/relativeLayout"
-                android:layout_width="wrap_content"
+            <AutoCompleteTextView
+                android:id="@+id/actvTimezone"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:completionThreshold="0"
+                android:hint="@string/select_timezone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tvTimeZone">
-
-                <Spinner
-                    android:id="@+id/availableID"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:spinnerMode="dialog" />
-
-            </RelativeLayout>
+                app:layout_constraintTop_toBottomOf="@+id/tvTimeZone" />
 
             <io.github.project_travel_mate.utilities.CustomAnalogClock
                 android:id="@+id/clock_analog"
@@ -54,7 +48,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/relativeLayout" />
+                app:layout_constraintTop_toBottomOf="@+id/actvTimezone" />
 
             <android.widget.TextClock
                 android:id="@+id/clock_digital"

--- a/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
@@ -28,6 +28,21 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <android.widget.TextClock
+                android:id="@+id/clock_digital"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center|bottom"
+                android:format12Hour="@string/date_format_hours_12"
+                android:format24Hour="@string/date_format_hours_24"
+                android:textColor="@android:color/black"
+                android:textSize="24sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/clock_analog" />
+
             <io.github.project_travel_mate.utilities.CustomAnalogClock
                 android:id="@+id/clock_analog"
                 android:layout_width="match_parent"
@@ -38,21 +53,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/actvTimezone" />
-
-            <android.widget.TextClock
-                android:id="@+id/clock_digital"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center|bottom"
-                android:textColor="@android:color/black"
-                android:textSize="24sp"
-                android:textStyle="bold"
-                android:format12Hour="@string/date_format_hours_12"
-                android:format24Hour="@string/date_format_hours_24"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/clock_analog" />
         </android.support.constraint.ConstraintLayout>
 
 

--- a/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
@@ -3,14 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent" >
+    android:layout_height="fill_parent"
+    android:background="@color/white">
 
     <FrameLayout
         android:id="@+id/root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:background="@color/white"
         tools:context=".utilities.WorldClockActivity">
 
         <android.support.constraint.ConstraintLayout

--- a/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
+++ b/Android/app/src/main/res/layout/activity_utilities_world_clock.xml
@@ -58,6 +58,8 @@
                 android:textColor="@android:color/black"
                 android:textSize="24sp"
                 android:textStyle="bold"
+                android:format12Hour="@string/date_format_hours_12"
+                android:format24Hour="@string/date_format_hours_24"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/Android/app/src/main/res/layout/item_timezone.xml
+++ b/Android/app/src/main/res/layout/item_timezone.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/ivTimezoneFlag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/description_timezone_flag"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/tvTimezoneLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/ivTimezoneFlag"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@tools:sample/cities" />
+
+</android.support.constraint.ConstraintLayout>

--- a/Android/app/src/main/res/layout/item_timezone.xml
+++ b/Android/app/src/main/res/layout/item_timezone.xml
@@ -7,8 +7,8 @@
 
     <ImageView
         android:id="@+id/ivTimezoneFlag"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:contentDescription="@string/description_timezone_flag"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -390,4 +390,8 @@
     <!-- Image description related strings -->
     <string name="description_timezone_flag">Timezone flag</string>
 
+    <!-- Date / time formatting related strings -->
+    <string name="date_format_hours_12">hh:mm:ss a</string>
+    <string name="date_format_hours_24">k:mm:ss</string>
+
 </resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -385,4 +385,9 @@
     <string name="add_widget">Add World Clock Widget</string>
     <string name="configure">Select Timezone For Clock Widget</string>
     <string name="toast_no_internet_detected">We couldn\'t find an active internet connection. Please try again.</string>
+
+
+    <!-- Image description related strings -->
+    <string name="description_timezone_flag">Timezone flag</string>
+
 </resources>


### PR DESCRIPTION
## Description
I took some time to rework the world clock UI.
It doesn't use a Spinner anymore but an AutoCompleteTextView which allow the user to type in the researched timezone.

Data we're manipulating right here are timezones and not countries. Flag is deducted from timezone with this algorithm : 
`
String country = timezone.contains("/") ? timezone.split("/")[1] : timezone;
`
Some countries doesn't exists in the World library so it will display a globe if the required country doesn't exists (see screenshot number 3)

⚠️ I decided to keep each feature in its own branch. Please be sure to merge #783 before this one.
If you want to test it locally, please cherrypick c3c85aee4fcc3a5b2d21d52cbe2b56c154e8cca0 to make sur that the World library is loaded.

![Screenshot_1572141448](https://user-images.githubusercontent.com/7251970/67628478-6bc5f980-f866-11e9-805b-7c69b83dbc5e.png)
![Screenshot_1572141450](https://user-images.githubusercontent.com/7251970/67628479-6bc5f980-f866-11e9-8870-f2fa2ccba07f.png)
![Screenshot_1572141457](https://user-images.githubusercontent.com/7251970/67628477-6b2d6300-f866-11e9-89d6-b7c8d4ffbaf3.png)

Fixes #737

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
