### PR TITLE
Hide citiesTravelledHeading in offline mode

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -733,6 +733,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
         editDisplayName.setVisibility(View.INVISIBLE);
         editDisplayStatus.setVisibility(View.INVISIBLE);
         changeImage.setVisibility(View.INVISIBLE);
+        citiesTravelledHeading.setVisibility(View.INVISIBLE);
 
         displayName.setText(name);
         emailId.setText(email);


### PR DESCRIPTION
## Description
hide visited cities in offline mode profile activity because we can't load Cities in offline mode

Fixes #794 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
