### PR TITLE
Fix upload profile picture issue

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -781,7 +781,7 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
 
             @Override
             public void onError(String requestId, ErrorInfo error) {
-                Toast.makeText(ProfileActivity.this, "Can't upload profile picture", Toast.LENGTH_SHORT).show();
+                Toast.makeText(ProfileActivity.this, getString(R.string.toast_upload_picture_issue), Toast.LENGTH_SHORT).show();
                 Log.e(LOG_TAG, "error uploading to Cloudinary");
             }
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -344,10 +344,6 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
             CropImage.ActivityResult result = CropImage.getActivityResult(data);
             if (resultCode == RESULT_OK) {
                 Uri croppedImage = result.getUri();
-                Picasso.with(this).load(croppedImage).into(displayImage);
-                mSharedPreferences.edit().putString(USER_IMAGE, croppedImage.toString()).apply();
-                TravelmateSnackbars.createSnackBar(findViewById(R.id.layout), R.string.profile_picture_updated,
-                        Snackbar.LENGTH_SHORT).show();
                 getUrlFromCloudinary(croppedImage);
             }
         }
@@ -769,13 +765,23 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
 
             @Override
             public void onSuccess(String requestId, Map resultData) {
+                Picasso.with(ProfileActivity.this)
+                        .load(croppedImage)
+                        .error(R.drawable.default_user_icon)
+                        .into(displayImage);
+
+                mSharedPreferences.edit().putString(USER_IMAGE, croppedImage.toString()).apply();
+
+                TravelmateSnackbars.createSnackBar(findViewById(R.id.layout), R.string.profile_picture_updated,
+                        Snackbar.LENGTH_SHORT).show();
+
                 mProfileImageUrl = resultData.get("url").toString();
                 sendURLtoServer(mProfileImageUrl);
             }
 
             @Override
             public void onError(String requestId, ErrorInfo error) {
-                networkError();
+                Toast.makeText(ProfileActivity.this, "Can't upload profile picture", Toast.LENGTH_SHORT).show();
                 Log.e(LOG_TAG, "error uploading to Cloudinary");
             }
 

--- a/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/ProfileActivity.java
@@ -781,7 +781,8 @@ public class ProfileActivity extends AppCompatActivity implements TravelmateSnac
 
             @Override
             public void onError(String requestId, ErrorInfo error) {
-                Toast.makeText(ProfileActivity.this, getString(R.string.toast_upload_picture_issue), Toast.LENGTH_SHORT).show();
+                Toast.makeText(ProfileActivity.this, getString(R.string.toast_upload_picture_issue),
+                        Toast.LENGTH_SHORT).show();
                 Log.e(LOG_TAG, "error uploading to Cloudinary");
             }
 

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -393,5 +393,6 @@
     <!-- Date / time formatting related strings -->
     <string name="date_format_hours_12">hh:mm:ss a</string>
     <string name="date_format_hours_24">k:mm:ss</string>
+    <string name="toast_upload_picture_issue">Can\'t upload profile picture</string>
 
 </resources>


### PR DESCRIPTION
## Description

All views will be gone when user can't upload profile picture to server but the right solution is to show state toast that he can't update profile picture 

## screenshot before
![empty](https://user-images.githubusercontent.com/23631699/70663452-0a6cb500-1c71-11ea-8ef3-c18dd51f26eb.PNG)

## screenshot after
![pic_after](https://user-images.githubusercontent.com/23631699/70663306-bfeb3880-1c70-11ea-9440-c5a9166dd23a.PNG)

Fixes #(issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
