### PR TITLE
#803-FlipViewPager has an issue with the number of pages

### DIFF
--- a/Android/app/src/main/java/io/github/project_travel_mate/destinations/CityAdapter.java
+++ b/Android/app/src/main/java/io/github/project_travel_mate/destinations/CityAdapter.java
@@ -29,6 +29,7 @@ class CityAdapter extends BaseFlipAdapter<City> {
 
     private final Activity mContext;
     private final int[] mIdsInterest = {R.id.interest_1, R.id.interest_2, R.id.interest_3, R.id.interest_4};
+    private final int mPagesPerRow = 3;
     private List<City> mCityList;
 
     CityAdapter(Context context, List<City> items, FlipSettings settings) {
@@ -83,9 +84,7 @@ class CityAdapter extends BaseFlipAdapter<City> {
 
     @Override
     public int getPagesCount() {
-        if (mCityList != null)
-            return mCityList.size();
-        return 5;
+        return mPagesPerRow;
     }
 
     private void fillHolder(CitiesHolder holder, CitiesInfoHolder infoHolder, final City city) {


### PR DESCRIPTION
## Description
The bug is being caused in the CityAdapter class by the getPagesCount() method returning the total number of cities as the page count (in this case 10), there are 10 items (cities) each with three pages only. A class constant has been created and is returned by getPageCount to avoid any behaviour changes that may affect other code.

Fixes #803 

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Built, run and tested to confirm bug fixed.

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
